### PR TITLE
Remove description from skill

### DIFF
--- a/db/migrate/20170817091527_remove_description_from_skill.rb
+++ b/db/migrate/20170817091527_remove_description_from_skill.rb
@@ -1,0 +1,5 @@
+class RemoveDescriptionFromSkill < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :skills, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170816133944) do
+ActiveRecord::Schema.define(version: 20170817091527) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -67,9 +67,8 @@ ActiveRecord::Schema.define(version: 20170816133944) do
 
   create_table "skills", force: :cascade do |t|
     t.string   "title"
-    t.text     "description"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "user_skills", force: :cascade do |t|


### PR DESCRIPTION
We weren't using the description in skill, so it's been removed from the database. #dry