### PR TITLE
title no longer unique

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -2,7 +2,7 @@ class Project < ApplicationRecord
   belongs_to :user
   has_many :host_reviews
   has_many :jobs
-  validates :title, presence: true, uniqueness: true
+  validates :title, presence: true
   validates :description, presence: true
   validates :schedule, presence: true
   validates :location, presence: true


### PR DESCRIPTION
Changed validation for project. Titles no longer have to be unique so that users can create a project even if a previous project had the same name.